### PR TITLE
Fetch git improvements

### DIFF
--- a/fetch-git/src/archives.py
+++ b/fetch-git/src/archives.py
@@ -45,6 +45,11 @@ class BranchArchive:
 
     def make_archive(self):
         if not self.__exists():
+            log.warning("Fetching branch '{}' at rev '{}' from {}".format(
+                self.branch,
+                self.revision,
+                self.cache.repository
+            ))
             with self.cache.lock():
                 bare_path = self.__bare_path()
 
@@ -149,6 +154,10 @@ class TagArchive:
 
     def make_archive(self):
         if not self.__exists():
+            log.warning("Fetching tag '{}' from {}".format(
+                self.tag,
+                self.cache.repository
+                ))
             with self.cache.lock():
                 bare_path = self.__bare_path()
                 ref = "refs/tags/{}".format(self.tag)

--- a/fetch-git/src/archives.py
+++ b/fetch-git/src/archives.py
@@ -93,7 +93,12 @@ class BranchArchive:
             cmd(self.__bare_path(), ["git", "cat-file", "-e",
                                      "{}^{{commit}}".format(self.revision)])
             return True
-        except subprocess.CalledProcessError:
+        except subprocess.CalledProcessError as e:
+            log.debug(
+                "Did not find commit {} and instead got output: {}".format(
+                    self.revision, e.output
+                )
+            )
             return False
 
     def __fetch_depth(self, depth):
@@ -169,7 +174,13 @@ class TagArchive:
                                     "--depth=1",
                                     self.cache.repository,
                                     ref])
-                except subprocess.CalledProcessError:
+                except subprocess.CalledProcessError as e:
+                    log.debug(
+                        "Did not find tag {}, instead got output: {}".format(
+                            self.tag, e.output
+                        )
+                    )
+
                     raise NixError(
                         "tag-not-found",
                         "Tag {} not found".format(self.tag)

--- a/fetch-git/src/command.py
+++ b/fetch-git/src/command.py
@@ -8,9 +8,10 @@ def cmd(cwd, command):
         cwd
         ))
 
-    return subprocess.run(command,
-                          cwd=cwd,
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.STDOUT,
-                          universal_newlines=True,
-                          check=True)
+    result = subprocess.run(command,
+                            cwd=cwd,
+                            stdout=subprocess.PIPE,
+                            universal_newlines=True,
+                            check=True)
+    log.debug("command output: {}".format(result.stdout))
+    return result

--- a/fetch-git/src/fetch-git.py
+++ b/fetch-git/src/fetch-git.py
@@ -10,6 +10,10 @@ from repository import RepositoryCache
 from nixerrors import NixError
 
 
+def dont_break_out_of_double_single_quotes(msg):
+    return msg.replace("''", '""')  # oh my word
+
+
 def print_success(outPath):
     nixPattern = """
 (let
@@ -21,7 +25,8 @@ in data // {{
     print(nixPattern.format(
       json.dumps({
           "outPath": archive.make_archive(),
-          "debug": log.debug_msgs
+          "debug": [dont_break_out_of_double_single_quotes(msg)
+                    for msg in log.debug_msgs]
       })
     ))
 
@@ -100,6 +105,7 @@ except NixError as e:
       json.dumps({
           "error": e.failure_type,
           "message": e.message,
-          "debug": log.debug_msgs
+          "debug": [dont_break_out_of_double_single_quotes(msg)
+                    for msg in log.debug_msgs]
       })
     ))

--- a/fetch-git/src/log.py
+++ b/fetch-git/src/log.py
@@ -9,5 +9,5 @@ def debug(msg):
 
 
 def warning(msg):
-    print(msg, file=sys.stderr)
+    print(f"fetch-git: {msg}", file=sys.stderr)
     debug(msg)


### PR DESCRIPTION
1. Indicate when we're fetching to be a bit more transparent, and let stderr flow through so they can see git stream fetch progress
2. Capture stdout in the debug logs to help with troubleshooting