### PR TITLE
fetch-pypi-hash: Fix an incorrect variable default expansion

### DIFF
--- a/fetch-pypi-hash/fetch-pypi-hash
+++ b/fetch-pypi-hash/fetch-pypi-hash
@@ -120,7 +120,7 @@ main() {
     local -r version="$2"
     local -r filename="$3"
 
-    local -r cache_base="${XDG_CACHE_HOME-:$HOME/.cache}/nix-fetchers"
+    local -r cache_base="${XDG_CACHE_HOME:-$HOME/.cache}/nix-fetchers"
     local -r cache_dir="$cache_base/fetchpypi/$name/$version/$filename"
     if [ ! -f "$cache_dir/default.nix" ]; then
         fetch_json "$name" "$version"


### PR DESCRIPTION
Does what it says on the tin. Without this, if `$XDG_CACHE_HOME` is not set, the cache directory path will end up being `./:/$HOME/.cache/nix-fetchers`.